### PR TITLE
win32 asyncio patch

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -4,8 +4,15 @@
 # Adapted from https://github.com/kyopark2014/strands-agent
 # SPDX-License-Identifier: MIT
 
-import logging
+import asyncio
 import sys
+
+# Set the correct asyncio event loop policy if using Windows
+# BEFORE streamlit has a chance to create its own default loop - which does not allow subprocess managing, causing it to break before anything.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+import logging
 
 import streamlit as st
 


### PR DESCRIPTION
*Issue #, if available:*
New

*Description of changes:*
Changed the handling of asyncio in windows that blocks it from starting any chat.

 Set the correct asyncio event loop policy if using Windows
 BEFORE streamlit has a chance to create its own default loop - which does not allow subprocess managing, causing it to break before anything.
```
if sys.platform == "win32":
    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
